### PR TITLE
add apache http client dependency

### DIFF
--- a/odnoklassniki-android-sdk/build.gradle
+++ b/odnoklassniki-android-sdk/build.gradle
@@ -13,4 +13,5 @@ android {
     }
     productFlavors {
     }
+    useLibrary 'org.apache.http.legacy'
 }


### PR DESCRIPTION
In Android Marshmallow (Api 23 ) Google removed  the support of Apache HTTP client
