### PR TITLE
Revert min sdk version to 9

### DIFF
--- a/odnoklassniki-android-sdk/build.gradle
+++ b/odnoklassniki-android-sdk/build.gradle
@@ -9,7 +9,7 @@ android {
     compileSdkVersion rootProject.property("android.compile.sdk.version") as int
     buildToolsVersion rootProject.property("android.build.tools.version")
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 9
         targetSdkVersion 24
     }
     productFlavors {


### PR DESCRIPTION
A few releases ago minSdk version was changed to 16 however it can perfectly work with minSdk=9 without any issues. I just ran lint  with minSdk = 9 and no issues were found. I suggest to revert minSdk verion to 9. It will allow more projects to use OK sdk